### PR TITLE
Fix: Slot flickering when built with Sapper

### DIFF
--- a/Transition.svelte
+++ b/Transition.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { onMount } from 'svelte';
+    import { onMount, tick } from 'svelte';
 
     export let toggle = undefined;
     export let transitions = '';
@@ -14,6 +14,7 @@
     let slot;
     let slotClasses;
     let parent;
+    let mounted;
 
     const STATE = {
         IDLE: 0,
@@ -23,7 +24,11 @@
 
     let state = STATE.IDLE;
 
-    onMount(() => {
+    onMount(async () => {
+        mounted = true;
+
+        await tick();
+
         slot = div.nextElementSibling;
         slotClasses = slot.classList.value;
 
@@ -143,4 +148,7 @@
     bind:this={div}
     hidden
 />
-<slot />
+
+{#if mounted}
+    <slot />
+{/if}


### PR DESCRIPTION
# Fix: Slot flickering when built with Sapper

Hey, continuing our discuss from discord here!

When using the transition component with Sapper the slots of each flicker on initial page load. This is happening because Sapper separates HTML/CSS from the Javascript bundles and the default style of the slot is loading before the component can set initial classes.

From your insight i've added a mounted check so the slot is not rendered by default. I am not sure this is the best solution, but its a good starting place 😄 

Example
```
<Transition
  toggle={value}
  inTransition="ease-out duration-200"
  inState="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
  onState="opacity-100 translate-y-0 sm:scale-100"
  outState="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
  outTransition="ease-in duration-100"
>
  <div 
    class={`absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2
      bg-gray-850 rounded-lg text-white px-4 py-3 overflow-hidden shadow-xl transition-all
      w-full h-full max-w-lg max-h-32 z-20`} >
  </div>
</Transition>
``` 

![flicker](https://user-images.githubusercontent.com/6911907/84951092-ebd2f500-b0bd-11ea-9f2c-3415aba7212b.gif)
